### PR TITLE
Fix unset custom constants during bootstrap

### DIFF
--- a/src/includes/bootstrap.php
+++ b/src/includes/bootstrap.php
@@ -156,6 +156,14 @@ if ( isset( $GLOBALS['wp_tests_options'] ) ) {
 	}
 }
 
+if (!empty($this->config['constants'])) {
+    foreach ( $this->config['constants'] as $key => $value ) {
+        if ( ! defined( $key ) ) {
+            define($key, $value);
+        }
+    }
+}
+
 // Load WordPress: "untrailingslash" ABSPATH first of all to avoid double slashes in filepath,
 // while still working if ABSPATH did not include a trailing slash
 require_once rtrim( ABSPATH, '/\\' ) . '/wp-settings.php';


### PR DESCRIPTION
Fixes:

> [PHPUnit_Framework_Exception]                                        
>   Use of undefined constant DB_NAME_STATIC - assumed 'DB_NAME_STATIC'  
>                                                                        
> 
> Exception trace:
>  () at /builds/foobar/foobar-website/vendor/codeception/codeception/src/Codeception/Subscriber/ErrorHandler.php:75
>  Codeception\Subscriber\ErrorHandler->errorHandler() at /builds/foobar/foobar-website/public/db-config.php:239
>  require() at /builds/foobar/foobar-website/public/wp-content/db.php:1445
>  require_once() at /builds/foobar/foobar-website/public/wp-includes/load.php:398
>  require_wp_db() at /builds/foobar/foobar-website/public/wp-settings.php:107
>  require_once() at /builds/foobar/foobar-website/vendor/lucatume/wp-browser/src/includes/bootstrap.php:161
>  require_once() at /builds/foobar/foobar-website/vendor/lucatume/wp-browser/src/Codeception/Module/WPLoader.php:229
>  Codeception\Module\WPLoader->loadWordPress() at /builds/foobar/foobar-website/vendor/lucatume/wp-browser/src/Codeception/Module/WPLoader.php:151
>  Codeception\Module\WPLoader->initialize() at /builds/foobar/foobar-website/vendor/lucatume/wp-browser/src/Codeception/Module/WPLoader.php:139
>  Codeception\Module\WPLoader->_initialize() at /builds/foobar/foobar-website/vendor/codeception/codeception/src/Codeception/SuiteManager.php:80
>  Codeception\SuiteManager->initialize() at /builds/foobar/foobar-website/vendor/codeception/codeception/src/Codeception/Codecept.php:182
>  Codeception\Codecept->runSuite() at /builds/foobar/foobar-website/vendor/codeception/codeception/src/Codeception/Codecept.php:153
>  Codeception\Codecept->run() at /builds/foobar/foobar-website/vendor/codeception/codeception/src/Codeception/Command/Run.php:366
>  Codeception\Command\Run->runSuites() at /builds/foobar/foobar-website/vendor/codeception/codeception/src/Codeception/Command/Run.php:293
>  Codeception\Command\Run->execute() at /builds/foobar/foobar-website/vendor/symfony/console/Command/Command.php:267
>  Symfony\Component\Console\Command\Command->run() at /builds/foobar/foobar-website/vendor/symfony/console/Application.php:846
>  Symfony\Component\Console\Application->doRunCommand() at /builds/foobar/foobar-website/vendor/symfony/console/Application.php:191
>  Symfony\Component\Console\Application->doRun() at /builds/foobar/foobar-website/vendor/symfony/console/Application.php:122
>  Symfony\Component\Console\Application->run() at /builds/foobar/foobar-website/vendor/codeception/codeception/src/Codeception/Application.php:103
>  Codeception\Application->run() at /builds/foobar/foobar-website/vendor/lucatume/wp-browser/wpcept:54